### PR TITLE
Release 0.5.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -577,7 +577,7 @@ dependencies = [
 
 [[package]]
 name = "olympian"
-version = "0.5.0"
+version = "0.5.1"
 dependencies = [
  "chronoutil",
  "faer",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "olympian"
-version = "0.5.0"
+version = "0.5.1"
 edition = "2021"
 description = "Quality control routines for meteorological observations"
 repository = "https://github.com/intarga/olympian/"


### PR DESCRIPTION
Cmake build breakage in rove requires us to cut a new version of it to fix the build of lard. However, 0.5.0 of olympian that rove depends on has a yanked version of faer in it's dependency tree, so we should really cut a new version of olympian first to fix that.